### PR TITLE
fix: beta-button

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Comfortable Atcoder",
-	"version": "1.5.3",
+	"version": "1.5.4",
 	"manifest_version": 2,
   "description": "Comfort your atcoder life. For more detail, visit https://github.com/drafear/comfortable-atcoder",
   "author": "drafear",
@@ -26,6 +26,11 @@
 		{
 			"matches": ["*://atcoder.jp/contests/*/submit*", "*://atcoder.jp/contests/*/tasks/*"],
 			"js": ["content/submission-warning.js"],
+			"run_at": "document_start"
+		},
+		{
+			"matches": ["*://*.contest.atcoder.jp/*"],
+			"js": ["content/link-to-beta.js"],
 			"run_at": "document_start"
 		}
 	],


### PR DESCRIPTION
*.contest.atcoder.jp 用の βへのリンクボタン を消してしまっていた
